### PR TITLE
Add insecure setting to allow connection with self-signed certs

### DIFF
--- a/vrealize/actions.go
+++ b/vrealize/actions.go
@@ -2,7 +2,6 @@ package vrealize
 
 import (
 	"fmt"
-	"github.com/dghubble/sling"
 )
 
 //ActionTemplate - is used to store action template
@@ -32,10 +31,9 @@ func (c *APIClient) GetActionTemplate(resourceViewsTemplate *ResourceViewsTempla
 
 	actionTemplate := new(ActionTemplate)
 	apiError := new(APIError)
+
 	//Set a REST call to perform an action on resource
-	_, err := sling.New().Set("Accept", "application/json").
-		Set("Content-Type", "application/json").Set("Authorization",
-		fmt.Sprintf("Bearer %s", c.BearerToken)).Get(actionURL).Receive(actionTemplate, apiError)
+	_, err := c.HTTPClient.New().Get(actionURL).Receive(actionTemplate, apiError)
 
 	if err != nil {
 		return nil, resourceViewsTemplate, err

--- a/vrealize/provider.go
+++ b/vrealize/provider.go
@@ -41,6 +41,12 @@ func providerSchema() map[string]*schema.Schema {
 			Description: "host name.domain name of the vRealize Automation server, " +
 				"for example, mycompany.mktg.mydomain.com.",
 		},
+		"insecure": {
+			Type:        schema.TypeBool,
+			Default:     false,
+			Optional:    true,
+			Description: "Specify whether to validate TLS certificates.",
+		},
 	}
 }
 
@@ -50,7 +56,9 @@ func providerConfig(r *schema.ResourceData) (interface{}, error) {
 	client := NewClient(r.Get("username").(string),
 		r.Get("password").(string),
 		r.Get("tenant").(string),
-		r.Get("host").(string))
+		r.Get("host").(string),
+		r.Get("insecure").(bool),
+	)
 
 	//Authenticate user
 	err := client.Authenticate()

--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -2,12 +2,12 @@ package vrealize
 
 import (
 	"fmt"
-	"github.com/dghubble/sling"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 //ResourceViewsTemplate - is used to store information
@@ -362,10 +362,8 @@ func (c *APIClient) DestroyMachine(destroyTemplate *ActionTemplate, resourceView
 	apiError := new(APIError)
 
 	//Set a REST call with delete resource request and delete resource template as a data
-	resp, err := sling.New().Set("Accept", "application/json").
-		Set("Content-Type", "application/json").Set("Authorization",
-		fmt.Sprintf("Bearer %s", c.BearerToken)).Post(destroyactionURL).BodyJSON(destroyTemplate).
-		Receive(actionResponse, apiError)
+	resp, err := c.HTTPClient.New().Post(destroyactionURL).
+		BodyJSON(destroyTemplate).Receive(actionResponse, apiError)
 
 	if resp.StatusCode != 201 {
 		return nil, err
@@ -392,10 +390,8 @@ func (c *APIClient) PowerOffMachine(powerOffTemplate *ActionTemplate, resourceVi
 	apiError := new(APIError)
 
 	//Set a rest call to power-off the resource with resource power-off template as a data
-	response, err := sling.New().Set("Accept", "application/json").
-		Set("Content-Type", "application/json").Set("Authorization",
-		fmt.Sprintf("Bearer %s", c.BearerToken)).Post(powerOffMachineactionURL).BodyJSON(powerOffTemplate).
-		Receive(actionResponse, apiError)
+	response, err := c.HTTPClient.New().Post(powerOffMachineactionURL).
+		BodyJSON(powerOffTemplate).Receive(actionResponse, apiError)
 
 	response.Close = true
 	if response.StatusCode == 201 {

--- a/vrealize/resource_test.go
+++ b/vrealize/resource_test.go
@@ -17,6 +17,7 @@ func init() {
 		"pass!@#",
 		"vsphere.local",
 		"http://localhost/",
+		true,
 	)
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -50,6 +51,7 @@ func TestNewClient(t *testing.T) {
 		password,
 		tenant,
 		baseURL,
+		true,
 	)
 
 	if client.Username != username {


### PR DESCRIPTION
Add an optional insecure setting (default to false) which will allow connection to systems using self-signed certificates. This change also cleans up some use of sling directly by using the cached HTTPClient connection.

Fixes #2 