### PR TITLE
Add ability to specify Description and Reasons fields for a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Example
 
 ```
     provider "vra7" {
-      username = "vRAUser1"
+      username = "vRAUser1@vsphere.local"
       password = "password123!"
       tenant = "corp.local.tenant"
-      host = "http://myvra.endpoint.local/"
+      host = "http://myvra.example.com/"
     }
 
 ```
@@ -156,7 +156,7 @@ Resource block contains two mandatory and three optional fields as follows
 
 * **resource_configuration** - *This is optional field. If blueprint properties have default values or no mandatory property value is required then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is service.field_name and value is any valid user input to the respective field.*
 
-* **catalog_configuration** - *This is optional field. if catalog properties have default values or no mandatory user input required for catalog service then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is any field name of catalog and value is any valid user input to the respective field.*
+* **catalog_configuration** - *This is an optional field. If catalog properties have default values or no mandatory user input required for catalog service then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is any field name of catalog and value is any valid user input to the respective field.*
 
 * **count** - *This field is used to create replicas of resources. If count is not provided then it will be considered as 1 by default.*
 
@@ -199,7 +199,8 @@ Save this configuration in main.tf in a path where the binary is placed.
 
 ## Execution
 
-There are three terraform commands that can be used on vRA plugin as follows.
+These are the terraform commands that can be used on vRA plugin as follows.
+* **terraform init** - *The init command is used to initialize a working directory containing Terraform configuration files.*
 
 * **terraform plan** - *Plan command shows plan for resources like how many resources will be provisioned and how many will be destroyed.*
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ set GOPATH=C:\TerraformPluginProject
 Create *~/.terraformrc* and put following content in it.
 ```
     providers {
-         vrealize = "/home/<USER>/TerraformPluginProject/bin/terraform-provider-vra7"
+         vra7 = "/home/<USER>/TerraformPluginProject/bin/terraform-provider-vra7"
     }
 ```
 
@@ -70,7 +70,7 @@ Create *~/.terraformrc* and put following content in it.
 Create *%APPDATA%/terraform.rc* and put following content in it.
 ```
     providers {
-         vrealize = "C:\TerraformPluginProject\bin\terraform-provider-vra7"
+         vra7 = "C:\\TerraformPluginProject\\bin\\terraform-provider-vra7.exe"
     }
 ```
 
@@ -90,7 +90,7 @@ Navigate to */home/<USER>/TerraformPluginProject/src/github.com/vmware/terraform
 
 ```
     dep ensure
-    go build -o /home/<USER>/TerraformPluginProject/bin/terraform-provider-realize
+    go build -o /home/<USER>/TerraformPluginProject/bin/terraform-provider-vra7
 
 ```
 
@@ -100,7 +100,7 @@ Navigate to *C:\TerraformPluginProject\src\github.com\vmware\terraform-provider-
 
 ```
     dep ensure
-    go build -o C:\TerraformPluginProject\bin\terraform-provider-realize.exe
+    go build -o C:\TerraformPluginProject\bin\terraform-provider-vra7.exe
 
 ```
 
@@ -127,8 +127,8 @@ Example
     provider "vra7" {
       username = "vRAUser1"
       password = "password123!"
-      tenant = "corp.loca.tenant"
-      host = "http://myvra.endipoint.local/"
+      tenant = "corp.local.tenant"
+      host = "http://myvra.endpoint.local/"
     }
 
 ```

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Resource block contains two mandatory and three optional fields as follows
 * **resource_configuration** - *This is optional field. If blueprint properties have default values or no mandatory property value is required then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is service.field_name and value is any valid user input to the respective field.*
 
 * **catalog_configuration** - *This is an optional field. If catalog properties have default values or no mandatory user input required for catalog service then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is any field name of catalog and value is any valid user input to the respective field.*
+* **deployment_configuration** - *This is an optional field. Can only beused to  specify the description or reasons field at the deployment level.*
 
 * **count** - *This field is used to create replicas of resources. If count is not provided then it will be considered as 1 by default.*
 
@@ -173,6 +174,10 @@ resource "vra7_resource" "example_machine1" {
      }
      catalog_configuration = {
          lease_days = "5"
+     }
+     deployment_configuration = {
+         reasons      = "I have some"
+         description  = "deployment via terraform"
      }
      count = 3
 }

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Resource block contains two mandatory and three optional fields as follows
 * **resource_configuration** - *This is optional field. If blueprint properties have default values or no mandatory property value is required then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is service.field_name and value is any valid user input to the respective field.*
 
 * **catalog_configuration** - *This is an optional field. If catalog properties have default values or no mandatory user input required for catalog service then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is any field name of catalog and value is any valid user input to the respective field.*
-* **deployment_configuration** - *This is an optional field. Can only be used to  specify the description or reasons field at the deployment level.*
+* **deployment_configuration** - *This is an optional field. Can only be used to  specify the description or reasons field at the deployment level.  Key is any field name of catalog and value is any valid user input to the respective field.*
 
 * **count** - *This field is used to create replicas of resources. If count is not provided then it will be considered as 1 by default.*
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Resource block contains two mandatory and three optional fields as follows
 * **resource_configuration** - *This is optional field. If blueprint properties have default values or no mandatory property value is required then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is service.field_name and value is any valid user input to the respective field.*
 
 * **catalog_configuration** - *This is an optional field. If catalog properties have default values or no mandatory user input required for catalog service then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is any field name of catalog and value is any valid user input to the respective field.*
-* **deployment_configuration** - *This is an optional field. Can only beused to  specify the description or reasons field at the deployment level.*
+* **deployment_configuration** - *This is an optional field. Can only be used to  specify the description or reasons field at the deployment level.*
 
 * **count** - *This field is used to create replicas of resources. If count is not provided then it will be considered as 1 by default.*
 

--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -268,7 +268,7 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 		case "reasons":
 			templateCatalogItem.Reasons = deploymentConfiguration[depField].(string)
 		default:
-			log.Printf("unknown option [%s] with value [%s] ignoring\n", field3, deploymentConfiguration[depField])
+			log.Printf("unknown option [%s] with value [%s] ignoring\n", depField, deploymentConfiguration[depField])
 		}
 	}
 	//Log print of template after values updated

--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -122,6 +122,15 @@ func setResourceSchema() map[string]*schema.Schema {
 			ForceNew: true,
 			Optional: true,
 		},
+		"deployment_configuration": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
 		"resource_configuration": {
 			Type:     schema.TypeMap,
 			Optional: true,
@@ -247,6 +256,20 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 		}
 		//delete used user configuration
 		delete(resourceConfiguration, configKey)
+	}
+	//update template with deployment level config
+	// limit to description and reasons as other things could get us into trouble
+	deploymentConfiguration, _ := d.Get("deployment_configuration").(map[string]interface{})
+	for depField := range deploymentConfiguration {
+		fieldstr := fmt.Sprintf("%s", depField)
+		switch fieldstr {
+		case "description":
+			templateCatalogItem.Description = deploymentConfiguration[depField].(string)
+		case "reasons":
+			templateCatalogItem.Reasons = deploymentConfiguration[depField].(string)
+		default:
+			log.Printf("unknown option [%s] with value [%s] ignoring\n", field3, deploymentConfiguration[depField])
+		}
 	}
 	//Log print of template after values updated
 	log.Printf("Updated template - %v\n", templateCatalogItem.Data)


### PR DESCRIPTION
Adds the ability and a new component to the resource allow user to specify the description and reasons fields as part of submitting the request. 
