### PR TITLE
Allowing 'description' and 'reasons' to be specified for a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Resource block contains two mandatory and three optional fields as follows
 * **resource_configuration** - *This is optional field. If blueprint properties have default values or no mandatory property value is required then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is service.field_name and value is any valid user input to the respective field.*
 
 * **catalog_configuration** - *This is an optional field. If catalog properties have default values or no mandatory user input required for catalog service then you can skip this field from terraform configuration file. This field contains user inputs to catalog services. Value of this field is in key value pair. Key is any field name of catalog and value is any valid user input to the respective field.*
+* **deployment_configuration** - *This is an optional field. Can only be used to  specify the description or reasons field at the deployment level.  Key is any field name of catalog and value is any valid user input to the respective field.*
 
 * **count** - *This field is used to create replicas of resources. If count is not provided then it will be considered as 1 by default.*
 
@@ -173,6 +174,10 @@ resource "vra7_resource" "example_machine1" {
      }
      catalog_configuration = {
          lease_days = "5"
+     }
+     deployment_configuration = {
+         reasons      = "I have some"
+         description  = "deployment via terraform"
      }
      count = 3
 }

--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -122,6 +122,15 @@ func setResourceSchema() map[string]*schema.Schema {
 			ForceNew: true,
 			Optional: true,
 		},
+		"deployment_configuration": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
 		"resource_configuration": {
 			Type:     schema.TypeMap,
 			Optional: true,
@@ -247,6 +256,20 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 		}
 		//delete used user configuration
 		delete(resourceConfiguration, configKey)
+	}
+	//update template with deployment level config
+	// limit to description and reasons as other things could get us into trouble
+	deploymentConfiguration, _ := d.Get("deployment_configuration").(map[string]interface{})
+	for depField := range deploymentConfiguration {
+		fieldstr := fmt.Sprintf("%s", depField)
+		switch fieldstr {
+		case "description":
+			templateCatalogItem.Description = deploymentConfiguration[depField].(string)
+		case "reasons":
+			templateCatalogItem.Reasons = deploymentConfiguration[depField].(string)
+		default:
+			log.Printf("unknown option [%s] with value [%s] ignoring\n", depField, deploymentConfiguration[depField])
+		}
 	}
 	//Log print of template after values updated
 	log.Printf("Updated template - %v\n", templateCatalogItem.Data)


### PR DESCRIPTION
Add deployment_configuration option in vra resource to allow the description and reasons fields to be set for a particular vRA deployment. This is explicitly limited to those two fields because otherwise it'd be possible to get into trouble by overwriting the businessgroupId, or catalogItemId etc.....




Signed-off-by: Carlos Tronco <cars@lostroncos.org>