### PR TITLE
destroy resource outside terraform  error message fixes

### DIFF
--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -334,6 +334,10 @@ func deleteResource(d *schema.ResourceData, meta interface{}) error {
 	//Set a delete machine template function call.
 	//Which will fetch and return the delete machine template from the given template
 	DestroyMachineTemplate, resourceTemplate, errDestroyAction := client.GetDestroyActionTemplate(templateResources)
+	if errDestroyAction.Error() == "resource is not created or not found" {
+		d.SetId("")
+		return fmt.Errorf("possibly resource got deleted outside terraform")
+	}
 	if errDestroyAction != nil {
 		return fmt.Errorf("Destory Machine action template failed to load: %v", errDestroyAction)
 	}


### PR DESCRIPTION
If a resource got deleted outside terraform, then while `terraform destroy` plugin throwing an error `resource is not created or not found` and resource stays in a state file.
I made the change to delete a resource from terraform state file and throw an error so a user will have an idea about that resource got deleted outside terraform.

Signed-off-by: Viraj Indasrao <virajindasrao@gmail.com>