### PR TITLE
use local repo for `vrealize` import

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/vmware/terraform-provider-vra7/vrealize"
+	"./vrealize"
 )
 
 func main() {


### PR DESCRIPTION
without this go will alway use the module that is on the master branch on GitHub, which means changes done to `vrealize` won't take effect.