### PR TITLE
Redo the error login in deleteResource to prevent panic

### DIFF
--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -446,13 +446,15 @@ func deleteResource(d *schema.ResourceData, meta interface{}) error {
 	//Set a delete machine template function call.
 	//Which will fetch and return the delete machine template from the given template
 	DestroyMachineTemplate, resourceTemplate, errDestroyAction := client.GetDestroyActionTemplate(templateResources)
-	if errDestroyAction.Error() == "resource is not created or not found" {
-		d.SetId("")
-		return fmt.Errorf("possibly resource got deleted outside terraform")
-	}
 	if errDestroyAction != nil {
+		if errDestroyAction.Error() == "resource is not created or not found" {
+			d.SetId("")
+			return fmt.Errorf("possibly resource got deleted outside terraform")
+		}
+
 		return fmt.Errorf("Destory Machine action template failed to load: %v", errDestroyAction)
 	}
+
 	//Set a destroy machine REST call
 	_, errDestroyMachine := client.DestroyMachine(DestroyMachineTemplate, resourceTemplate)
 	//Raise an exception if error got while deleting resource


### PR DESCRIPTION
Fix the error logic in deleteResource to check for nil first. Fixes #37.