### PR TITLE
Fixing issues related to create, update and read

### DIFF
--- a/utils/contants.go
+++ b/utils/contants.go
@@ -1,8 +1,38 @@
 package utils
 
 const (
-	REQUEST_STATUS = "request_status"
-	//utility constants
+	CATALOG_NAME             = "catalog_name"
+	CATALOG_ID               = "catalog_id"
+	BUSINESS_GROUP_ID        = "businessgroup_id"
+	BUSINESS_GROUP_NAME      = "businessgroup_name"
+	WAIT_TIME_OUT            = "wait_timeout"
+	FAILED_MESSAGE           = "failed_message"
+	DEPLOYMENT_CONFIGURATION = "deployment_configuration"
+	RESOURCE_CONFIGURATION   = "resource_configuration"
+	CATALOG_CONFIGURATION    = "catalog_configuration"
+	REQUEST_STATUS           = "request_status"
+	INFRASTRUCTURE_VIRTUAL   = "Infrastructure.Virtual"
+	COMPONENT                = "Component"
+	RECONFIGURE              = "Reconfigure"
+
+	// read resource machine constants
+	MACHINE_CPU              = "cpu"
+	MACHINE_STORAGE          = "storage"
+	MACHINE_MEMORY           = "memory"
+	IP_ADDRESS               = "ip_address"
+	MACHINE_NAME             = "name"
+	MACHINE_GUEST_OS         = "guest_operating_system"
+	MACHINE_BP_NAME          = "blueprint_name"
+	MACHINE_TYPE             = "type"
+	MACHINE_RESERVATION_NAME = "reservation_name"
+	MACHINE_INTERFACE_TYPE   = "interface_type"
+	MACHINE_ID               = "id"
+	MACHINE_GROUP_NAME       = "group_name"
+	MACHINE_DESTRUCTION_DATE = "destruction_date"
+	MACHINE_RECONFIGURE      = "reconfigure"
+	MACHINE_POWER_OFF        = "power_off"
+
+	// utility constants
 	LOGGER_ID              = "terraform-provider-vra7"
 	WINDOWS_PATH_SEPARATOR = "\\"
 	UNIX_PATH_SEPARATOR    = "/"
@@ -10,4 +40,15 @@ const (
 
 	//error constants
 	CONFIG_INVALID_ERROR = "The resource_configuration in the config file has invalid component name(s): %v "
+
+	// api constants
+	CATALOG_SERVICE               = "/catalog-service"
+	CATALOG_SERVICE_API           = CATALOG_SERVICE + "/api"
+	CONSUMER                      = CATALOG_SERVICE_API + "/consumer"
+	CONSUMER_REQUESTS             = CONSUMER + "/requests"
+	CONSUMER_RESOURCES            = CONSUMER + "/resources"
+	GET_RESOURCE_API              = CONSUMER_REQUESTS + "/" + "%s" + "/resources"
+	POST_ACTION_TEMPLATE_API      = CONSUMER_RESOURCES + "/" + "%s" + "/actions/" + "%s" + "/requests"
+	GET_ACTION_TEMPLATE_API       = POST_ACTION_TEMPLATE_API + "/template"
+	GET_REQUEST_RESOURCE_VIEW_API = CONSUMER_REQUESTS + "/" + "%s" + "/resourceViews"
 )

--- a/vrealize/action_test.go
+++ b/vrealize/action_test.go
@@ -3,8 +3,9 @@ package vrealize
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/jarcoal/httpmock.v1"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 //var client APIClient

--- a/vrealize/catalog_test.go
+++ b/vrealize/catalog_test.go
@@ -3,8 +3,9 @@ package vrealize
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/jarcoal/httpmock.v1"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func init() {
@@ -76,7 +77,7 @@ func TestFetchCatalogItemByName(t *testing.T) {
 		t.Errorf("Error while fetching catalog Item %v", err)
 	}
 
-	if catalogItemID == nil || catalogItemID == "" {
+	if catalogItemID == "" {
 		t.Errorf("Catalog ID is nil")
 	}
 
@@ -85,7 +86,7 @@ func TestFetchCatalogItemByName(t *testing.T) {
 	// This should return an error
 	catalogItemID, err = client.readCatalogItemIDByName("Cent OS 6.3")
 
-	if catalogItemID != nil && catalogItemID != "" {
+	if catalogItemID != "" {
 		t.Errorf("Catalog Item ID is not nil")
 	}
 
@@ -98,7 +99,7 @@ func TestFetchCatalogItemByName(t *testing.T) {
 	// This should return empty catalogItemID with suggestions with full name
 	catalogItemID, err = client.readCatalogItemIDByName("CentOS")
 
-	if catalogItemID != nil && catalogItemID != "" {
+	if catalogItemID != "" {
 		t.Errorf("Catalog Item ID is not nil")
 	}
 
@@ -115,7 +116,7 @@ func TestFetchCatalogItemByName(t *testing.T) {
 	// This should return empty catalogItemID with suggestions with full name
 	catalogItemID, err = client.readCatalogItemIDByName("CentOS")
 
-	if catalogItemID != nil {
+	if catalogItemID != "" {
 		t.Errorf("Catalog Item ID is not nil")
 	}
 
@@ -130,7 +131,7 @@ func TestFetchCatalogItemByName(t *testing.T) {
 		t.Errorf("Data fetched with wrong catalog ID")
 	}
 
-	if catalogItemID != nil {
+	if catalogItemID != "" {
 		t.Errorf("Wrong catalog data got fetched")
 	}
 	httpmock.Reset()
@@ -147,7 +148,7 @@ func TestFetchCatalogItemByName(t *testing.T) {
 		t.Errorf("Data fetched with wrong catalog item ID")
 	}
 
-	if catalogItemID != nil {
+	if catalogItemID != "" {
 		t.Errorf("Wrong catalog item data got fetched")
 	}
 
@@ -157,7 +158,6 @@ func TestFetchCatalogItemByName(t *testing.T) {
 		httpmock.NewStringResponder(500, entitledCatalogItemViewsErrorResp))
 	catalogItemID, err = client.readCatalogItemIDByName("CentOS")
 }
-
 
 // This unit test function contains test cases related to catalog ID in tf config files
 // Scenarios :
@@ -175,7 +175,7 @@ func TestFetchCatalogItemByID(t *testing.T) {
 		t.Errorf("Error while fetching catalog item %v", err)
 	}
 
-	if catalogItemName == nil {
+	if catalogItemName == "" {
 		t.Errorf("Catalog Item Name is is nil")
 	}
 
@@ -188,7 +188,7 @@ func TestFetchCatalogItemByID(t *testing.T) {
 		t.Errorf("Data fetched with wrong catalog ID")
 	}
 
-	if catalogItemName != nil {
+	if catalogItemName != "" {
 		t.Errorf("Wrong catalog item data got fetched")
 	}
 
@@ -200,7 +200,7 @@ func TestFetchCatalogItemByID(t *testing.T) {
 		t.Errorf("Data fetched with wrong catalog ID")
 	}
 
-	if catalogItemName != nil {
+	if catalogItemName != "" {
 		t.Errorf("Wrong catalog data got fetched")
 	}
 }

--- a/vrealize/resource.go
+++ b/vrealize/resource.go
@@ -16,178 +16,18 @@ import (
 )
 
 var (
-	log = logging.MustGetLogger(utils.LOGGER_ID)
+	log                     = logging.MustGetLogger(utils.LOGGER_ID)
+	catalogItemName         string
+	catalogItemID           string
+	businessGroupId         string
+	businessGroupName       string
+	waitTimeout             int
+	requestStatus           string
+	failedMessage           string
+	deploymentConfiguration map[string]interface{}
+	resourceConfiguration   map[string]interface{}
+	catalogConfiguration    map[string]interface{}
 )
-
-//ResourceActionTemplate - is used to store information
-//related to resource action template information.
-type ResourceActionTemplate struct {
-	Type        string                 `json:"type"`
-	ResourceID  string                 `json:"resourceId"`
-	ActionID    string                 `json:"actionId"`
-	Description string                 `json:"description"`
-	Data        map[string]interface{} `json:"data"`
-}
-
-//ResourceView - is used to store information
-//related to resource template information.
-type ResourceView struct {
-	Content []interface {
-	} `json:"content"`
-	Links []interface{} `json:"links"`
-}
-
-//RequestStatusView - used to store REST response of
-//request triggered against any resource.
-type RequestStatusView struct {
-	RequestCompletion struct {
-		RequestCompletionState string `json:"requestCompletionState"`
-		CompletionDetails      string `json:"CompletionDetails"`
-	} `json:"requestCompletion"`
-	Phase string `json:"phase"`
-}
-
-type BusinessGroups struct {
-	Content []BusinessGroup `json:"content,omitempty"`
-}
-
-type BusinessGroup struct {
-	Name string `json:"name,omitempty"`
-	Id   string `json:"id,omitempty"`
-}
-
-//CatalogRequest - A structure that captures a vRA catalog request.
-type CatalogRequest struct {
-	ID           string      `json:"id"`
-	IconID       string      `json:"iconId"`
-	Version      int         `json:"version"`
-	State        string      `json:"state"`
-	Description  string      `json:"description"`
-	Reasons      interface{} `json:"reasons"`
-	RequestedFor string      `json:"requestedFor"`
-	RequestedBy  string      `json:"requestedBy"`
-	Organization struct {
-		TenantRef      string `json:"tenantRef"`
-		TenantLabel    string `json:"tenantLabel"`
-		SubtenantRef   string `json:"subtenantRef"`
-		SubtenantLabel string `json:"subtenantLabel"`
-	} `json:"organization"`
-
-	RequestorEntitlementID   string                 `json:"requestorEntitlementId"`
-	PreApprovalID            string                 `json:"preApprovalId"`
-	PostApprovalID           string                 `json:"postApprovalId"`
-	DateCreated              time.Time              `json:"dateCreated"`
-	LastUpdated              time.Time              `json:"lastUpdated"`
-	DateSubmitted            time.Time              `json:"dateSubmitted"`
-	DateApproved             time.Time              `json:"dateApproved"`
-	DateCompleted            time.Time              `json:"dateCompleted"`
-	Quote                    interface{}            `json:"quote"`
-	RequestData              map[string]interface{} `json:"requestData"`
-	RequestCompletion        string                 `json:"requestCompletion"`
-	RetriesRemaining         int                    `json:"retriesRemaining"`
-	RequestedItemName        string                 `json:"requestedItemName"`
-	RequestedItemDescription string                 `json:"requestedItemDescription"`
-	Components               string                 `json:"components"`
-	StateName                string                 `json:"stateName"`
-
-	CatalogItemProviderBinding struct {
-		BindingID   string `json:"bindingId"`
-		ProviderRef struct {
-			ID    string `json:"id"`
-			Label string `json:"label"`
-		} `json:"providerRef"`
-	} `json:"catalogItemProviderBinding"`
-
-	Phase           string `json:"phase"`
-	ApprovalStatus  string `json:"approvalStatus"`
-	ExecutionStatus string `json:"executionStatus"`
-	WaitingStatus   string `json:"waitingStatus"`
-	CatalogItemRef  struct {
-		ID    string `json:"id"`
-		Label string `json:"label"`
-	} `json:"catalogItemRef"`
-}
-
-//ResourceMachine - use to set resource fields
-func ResourceMachine() *schema.Resource {
-	return &schema.Resource{
-		Create: createResource,
-		Read:   readResource,
-		Update: updateResource,
-		Delete: deleteResource,
-		Schema: setResourceSchema(),
-	}
-}
-
-//set_resource_schema - This function is used to update the catalog item template/blueprint
-//and replace the values with user defined values added in .tf file.
-func setResourceSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"catalog_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"catalog_id": {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		"businessgroup_id": {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		"businessgroup_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		"wait_timeout": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Default:  15,
-		},
-		utils.REQUEST_STATUS: {
-			Type:     schema.TypeString,
-			Computed: true,
-			ForceNew: true,
-		},
-		"failed_message": {
-			Type:     schema.TypeString,
-			Computed: true,
-			ForceNew: true,
-			Optional: true,
-		},
-		"deployment_configuration": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-			},
-		},
-		"resource_configuration": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-			},
-		},
-		"catalog_configuration": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-			},
-		},
-	}
-}
 
 //Replace the value for a given key in a catalog request template.
 func replaceValueInRequestTemplate(templateInterface map[string]interface{}, field string, value interface{}) (map[string]interface{}, bool) {
@@ -234,68 +74,18 @@ func addValueToRequestTemplate(templateInterface map[string]interface{}, field s
 func createResource(d *schema.ResourceData, meta interface{}) error {
 	// Get client handle
 	vRAClient := meta.(*APIClient)
-
-	// If catalog_name and catalog_id both not provided then return an error
-	if len(d.Get("catalog_name").(string)) <= 0 && len(d.Get("catalog_id").(string)) <= 0 {
-		return fmt.Errorf("Either catalog_name or catalog_id should be present in given configuration")
-	}
-
-	// If catalog item name is provided then get catalog item ID using name for further process
-	// else if catalog item id is provided then fetch catalog name
-	if len(d.Get("catalog_name").(string)) > 0 {
-		catalogItemID, returnErr := vRAClient.readCatalogItemIDByName(d.Get("catalog_name").(string))
-		log.Info("createResource->catalog_id %v\n", catalogItemID)
-		if returnErr != nil {
-			return fmt.Errorf("%v", returnErr)
-		}
-		if catalogItemID == nil {
-			return fmt.Errorf("No catalog item found with name %v", d.Get("catalog_name").(string))
-		} else if catalogItemID == "" {
-			return fmt.Errorf("No catalog item found with name %v", d.Get("catalog_name").(string))
-		}
-		d.Set("catalog_id", catalogItemID.(string))
-	} else if len(d.Get("catalog_id").(string)) > 0 {
-		CatalogItemName, nameError := vRAClient.readCatalogItemNameByID(d.Get("catalog_id").(string))
-		if nameError != nil {
-			return fmt.Errorf("%v", nameError)
-		}
-		if nameError != nil {
-			d.Set("catalog_name", CatalogItemName.(string))
-		}
-	}
+	readProviderConfiguration(d)
 	//Get request template for catalog item.
-	requestTemplate, err := vRAClient.GetCatalogItemRequestTemplate(d.Get("catalog_id").(string))
-	log.Info("createResource->requestTemplate %v\n", requestTemplate)
+	requestTemplate, err := vRAClient.GetCatalogItemRequestTemplate(d.Get(utils.CATALOG_ID).(string))
+	log.Info("The request template data corresponding to the catalog item %v is: \n %v\n", catalogItemID, requestTemplate.Data)
 
-	catalogConfiguration, _ := d.Get("catalog_configuration").(map[string]interface{})
+	validityErr := checkConfigValidity(vRAClient, d, requestTemplate)
+	if validityErr != nil {
+		return validityErr
+	}
+
 	for field1 := range catalogConfiguration {
 		requestTemplate.Data[field1] = catalogConfiguration[field1]
-
-	}
-	log.Info("createResource->requestTemplate.Data %v\n", requestTemplate.Data)
-
-	business_group_id := strings.TrimSpace(d.Get("businessgroup_id").(string))
-	business_group_name := strings.TrimSpace(d.Get("businessgroup_name").(string))
-
-	// get the business group id from name
-	var businessGroupIdFromName string
-	if len(business_group_name) > 0 {
-		businessGroupIdFromName, err = vRAClient.GetBusinessGroupId(business_group_name)
-		if err != nil || businessGroupIdFromName == "" {
-			return err
-		}
-	}
-
-	//if both business group name and id are provided but does not belong to the same business group, throw an error
-	if len(business_group_name) > 0 && len(business_group_id) > 0 && businessGroupIdFromName != business_group_id {
-		log.Error("The business group name %s and id %s does not belong to the same business group. Provide either name or id.", business_group_name, business_group_id)
-		return errors.New(fmt.Sprintf("The business group name %s and id %s does not belong to the same business group. Provide either name or id.", business_group_name, business_group_id))
-	} else if len(business_group_id) > 0 { // else if both are provided and matches or just id is provided, use id
-		log.Info("Setting business group id %s ", business_group_id)
-		requestTemplate.BusinessGroupID = business_group_id
-	} else if len(business_group_name) > 0 { // else if name is provided, use the id fetched from the name
-		log.Info("Setting business group id %s for the group %s ", businessGroupIdFromName, business_group_name)
-		requestTemplate.BusinessGroupID = businessGroupIdFromName
 	}
 
 	// Get all component names in the blueprint corresponding to the catalog item.
@@ -311,13 +101,6 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 	// Component names are sorted this way because '.', which is used as a separator, may also occur within
 	// component names. In these situations, the longest name match that includes '.'s should win.
 	sort.Sort(byLength(componentNameList))
-
-	resourceConfiguration, _ := d.Get("resource_configuration").(map[string]interface{})
-
-	validityErr := checkConfigValidity(requestTemplate, resourceConfiguration)
-	if validityErr != nil {
-		return validityErr
-	}
 
 	//Update request template field values with values from user configuration.
 	for configKey, configValue := range resourceConfiguration {
@@ -345,7 +128,6 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 
 	//update template with deployment level config
 	// limit to description and reasons as other things could get us into trouble
-	deploymentConfiguration, _ := d.Get("deployment_configuration").(map[string]interface{})
 	for depField, depValue := range deploymentConfiguration {
 		fieldstr := fmt.Sprintf("%s", depField)
 		switch fieldstr {
@@ -370,7 +152,6 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Resource Machine Request Failed: %v", err)
 	}
-
 	//Set request ID
 	d.SetId(catalogRequest.ID)
 	//Set request status
@@ -388,128 +169,110 @@ func updateRequestTemplate(templateInterface map[string]interface{}, field strin
 	return templateInterface
 }
 
-//Function use - to update centOS 6.3 machine present in state file
-//Terraform call - terraform refresh
-func readActionLink(resourceSpecificLinks []interface{}, reconfigGetLinkTitleRel string) string {
-	var actionLink string
-	for _, linkData := range resourceSpecificLinks {
-		linkInterface := linkData.(map[string]interface{})
-		if linkInterface["rel"] == reconfigGetLinkTitleRel {
-			//Get resource reconfiguration template link
-			actionLink = linkInterface["href"].(string)
-			break
-		}
-	}
-	return actionLink
-}
-
-func readVMReconfigActionUrls(GetDeploymentStateData *ResourceView) map[string]interface{} {
-
-	var urlMap map[string]interface{}
-	urlMap = map[string]interface{}{}
-	const reconfigGetLinkTitleRel = "GET Template: {com.vmware.csp.component.iaas.proxy.provider@resource.action.name." +
-		"machine.Reconfigure}"
-	const reconfigPostLinkTitleRel = "POST: {com.vmware.csp.component.iaas.proxy.provider@resource.action.name." +
-		"machine.Reconfigure}"
-
-	for _, value := range GetDeploymentStateData.Content {
-		resourceMap := value.(map[string]interface{})
-		if resourceMap["resourceType"] == "Infrastructure.Virtual" {
-			resourceSpecificData := resourceMap["data"].(map[string]interface{})
-			resourceSpecificLinks := resourceMap["links"].([]interface{})
-			componentName := resourceSpecificData["Component"].(string)
-
-			reconfigGetLink := readActionLink(resourceSpecificLinks, reconfigGetLinkTitleRel)
-			reconfigPostLink := readActionLink(resourceSpecificLinks, reconfigPostLinkTitleRel)
-			urlMap[componentName] = []string{reconfigGetLink, reconfigPostLink}
-		}
-	}
-	return urlMap
-}
-
 // Terraform call - terraform apply
 // This function updates the state of a vRA 7 Deployment when changes to a Terraform file are applied.
 // The update is performed on the Deployment using supported (day-2) actions.
 func updateResource(d *schema.ResourceData, meta interface{}) error {
-	//Get the ID of the catalog request that was used to provision this Deployment.
+
+	// Get the ID of the catalog request that was used to provision this Deployment.
 	catalogItemRequestID := d.Id()
-	//Get client handle
+	// Get client handle
 	vRAClient := meta.(*APIClient)
+	readProviderConfiguration(d)
 
 	//Get request template for catalog item.
-	requestTemplate, _ := vRAClient.GetCatalogItemRequestTemplate(d.Get("catalog_id").(string))
-	log.Info("createResource->requestTemplate %v\n", requestTemplate)
+	requestTemplate, err := vRAClient.GetCatalogItemRequestTemplate(d.Get(utils.CATALOG_ID).(string))
+	log.Info("The request template data corresponding to the catalog item %v is: \n %v\n", catalogItemID, requestTemplate.Data)
 
-	resourceConfiguration, _ := d.Get("resource_configuration").(map[string]interface{})
-
-	validityErr := checkConfigValidity(requestTemplate, resourceConfiguration)
+	validityErr := checkConfigValidity(vRAClient, d, requestTemplate)
 	if validityErr != nil {
 		return validityErr
 	}
 
-	//If any change made in resource_configuration.
-	if d.HasChange("resource_configuration") {
+	ResourceActions := new(ResourceActions)
+	apiError := new(APIError)
 
-		//Read resource template
-		GetDeploymentStateData, errTemplate := vRAClient.GetDeploymentState(catalogItemRequestID)
-		if errTemplate != nil {
-			return fmt.Errorf("Resource view failed to load:  %v", errTemplate)
-		}
+	path := fmt.Sprintf(utils.GET_RESOURCE_API, catalogItemRequestID)
+	_, err = vRAClient.HTTPClient.New().Get(path).
+		Receive(ResourceActions, apiError)
 
-		VMReconfigActionUrls := readVMReconfigActionUrls(GetDeploymentStateData)
+	if err != nil {
+		log.Errorf("Error while reading resource actions for the request %v: %v ", catalogItemRequestID, err.Error())
+		return fmt.Errorf("Error while reading resource actions for the request %v: %v  ", catalogItemRequestID, err.Error())
+	}
+	if apiError != nil {
+		log.Errorf("Error while reading resource actions for the request %v: %v ", catalogItemRequestID, apiError.Error())
+		return fmt.Errorf("Error while reading resource actions for the request %v: %v  ", catalogItemRequestID, apiError.Error())
+	}
 
-		//Iterate over the resources in the deployment
-		for _, value := range GetDeploymentStateData.Content {
-			resourceMap := value.(map[string]interface{})
-			if resourceMap["resourceType"] == "Infrastructure.Virtual" {
-				resourceSpecificData := resourceMap["data"].(map[string]interface{})
-				//resourceSpecificLinks := resourceMap["links"].([]interface{})
-				componentName := resourceSpecificData["Component"].(string)
-				resourceActionTemplate := new(ResourceActionTemplate)
-				apiError := new(APIError)
-				//Get reource child reconfiguration template json
-				response, err := vRAClient.HTTPClient.New().Get(VMReconfigActionUrls[componentName].([]string)[0]).
-					Receive(resourceActionTemplate, apiError)
-				response.Close = true
-
-				if !apiError.isEmpty() {
-					return apiError
-				}
-				if err != nil {
-					return err
-				}
-				configChanged := false
-				returnFlag := false
-				for configKey := range resourceConfiguration {
-					//compare resource list (resource_name) with user configuration fields
-					if strings.HasPrefix(configKey, componentName+".") {
-						//If user_configuration contains resource_list element
-						// then split user configuration key into resource_name and field_name
-						nameList := strings.Split(configKey, componentName+".")
-						//actionResponseInterface := actionResponse.(map[string]interface{})
-						//Function call which changes the template field values with  user values
-						//Replace existing values with new values in resource child template
-						resourceActionTemplate.Data, returnFlag = replaceValueInRequestTemplate(
-							resourceActionTemplate.Data,
-							nameList[1],
-							resourceConfiguration[configKey])
-						if returnFlag == true {
-							configChanged = true
-						}
-
+	// If any change made in resource_configuration.
+	if d.HasChange(utils.RESOURCE_CONFIGURATION) {
+		for _, resources := range ResourceActions.Content {
+			if resources.ResourceTypeRef.Id == utils.INFRASTRUCTURE_VIRTUAL {
+				var reconfigureEnabled bool
+				var reconfigureActionId string
+				for _, op := range resources.Operations {
+					if op.Name == utils.RECONFIGURE {
+						reconfigureEnabled = true
+						reconfigureActionId = op.OperationId
+						break
 					}
-					//delete used user configuration
-					//delete(resourceConfiguration, configKey)
 				}
-				//If template value got changed then set post call and update resource child
-				if configChanged != false {
-					err := postResourceConfig(
-						d,
-						VMReconfigActionUrls[componentName].([]string)[1],
-						resourceActionTemplate,
-						meta)
-					if err != nil {
-						return err
+				// if reconfigure action is not available for any resource of the deployment
+				// return with an error message
+				if !reconfigureEnabled {
+					return fmt.Errorf("Update is not allowed for resource %v, your entitlement has no Reconfigure action enabled", resources.Id)
+				} else {
+					resourceData := resources.ResourceData
+					entries := resourceData.Entries
+					for _, entry := range entries {
+						if entry.Key == utils.COMPONENT {
+							entryValue := entry.Value
+							componentName := entryValue.Value.(string)
+							resourceActionTemplate := new(ResourceActionTemplate)
+							apiError := new(APIError)
+							log.Info("Retrieving reconfigure action template for the component: %v ", componentName)
+							getActionTemplatePath := fmt.Sprintf(utils.GET_ACTION_TEMPLATE_API, resources.Id, reconfigureActionId)
+							response, err := vRAClient.HTTPClient.New().Get(getActionTemplatePath).
+								Receive(resourceActionTemplate, apiError)
+							response.Close = true
+							if !apiError.isEmpty() {
+								log.Errorf("Error retrieving reconfigure action template for the component %v: %v ", componentName, apiError.Error())
+								return fmt.Errorf("Error retrieving reconfigure action template for the component %v: %v ", componentName, apiError.Error())
+							}
+							if err != nil {
+								log.Errorf("Error retrieving reconfigure action template for the component %v: %v ", componentName, err.Error())
+								return fmt.Errorf("Error retrieving reconfigure action template for the component %v: %v ", componentName, err.Error())
+							}
+							configChanged := false
+							returnFlag := false
+							for configKey := range resourceConfiguration {
+								//compare resource list (resource_name) with user configuration fields
+								if strings.HasPrefix(configKey, componentName+".") {
+									//If user_configuration contains resource_list element
+									// then split user configuration key into resource_name and field_name
+									nameList := strings.Split(configKey, componentName+".")
+									//actionResponseInterface := actionResponse.(map[string]interface{})
+									//Function call which changes the template field values with  user values
+									//Replace existing values with new values in resource child template
+									resourceActionTemplate.Data, returnFlag = replaceValueInRequestTemplate(
+										resourceActionTemplate.Data,
+										nameList[1],
+										resourceConfiguration[configKey])
+									if returnFlag == true {
+										configChanged = true
+									}
+								}
+							}
+							// If template value got changed then set post call and update resource child
+							if configChanged != false {
+								postActionTemplatePath := fmt.Sprintf(utils.POST_ACTION_TEMPLATE_API, resources.Id, reconfigureActionId)
+								err := postResourceConfig(d, postActionTemplatePath, resourceActionTemplate, meta)
+								if err != nil {
+									return err
+								}
+							}
+						}
 					}
 				}
 			}
@@ -527,16 +290,15 @@ func postResourceConfig(d *schema.ResourceData, reconfigPostLink string, resourc
 		BodyJSON(resourceActionTemplate).Receive(resourceActionTemplate2, apiError2)
 
 	if response2.StatusCode != 201 {
-		oldData, _ := d.GetChange("resource_configuration")
-		d.Set("resource_configuration", oldData)
+		oldData, _ := d.GetChange(utils.RESOURCE_CONFIGURATION)
+		d.Set(utils.RESOURCE_CONFIGURATION, oldData)
 		return apiError2
 	}
 	response2.Close = true
 	if !apiError2.isEmpty() {
-		oldData, _ := d.GetChange("resource_configuration")
-		d.Set("resource_configuration", oldData)
+		oldData, _ := d.GetChange(utils.RESOURCE_CONFIGURATION)
+		d.Set(utils.RESOURCE_CONFIGURATION, oldData)
 		return apiError2
-		//panic(d)
 	}
 	return nil
 }
@@ -545,109 +307,82 @@ func postResourceConfig(d *schema.ResourceData, reconfigPostLink string, resourc
 // This function retrieves the latest state of a vRA 7 deployment. Terraform updates its state based on
 // the information returned by this function.
 func readResource(d *schema.ResourceData, meta interface{}) error {
-	//Get the ID of the catalog request that was used to provision this Deployment.
+	// Get the ID of the catalog request that was used to provision this Deployment.
 	catalogItemRequestID := d.Id()
-	//Get client handle
+
+	log.Info("Calling read resource to get the current resource status of the request: %v ", catalogItemRequestID)
+	// Get client handle
 	vRAClient := meta.(*APIClient)
-	//Get requested status
+	// Get requested status
 	resourceTemplate, errTemplate := vRAClient.GetRequestStatus(catalogItemRequestID)
 
-	//Raise an exception if error occured while fetching request status
 	if errTemplate != nil {
+		log.Errorf("Resource view failed to load:  %v", errTemplate)
 		return fmt.Errorf("Resource view failed to load:  %v", errTemplate)
 	}
-	//Update resource request status in state file
+
+	// Update resource request status in state file
 	d.Set(utils.REQUEST_STATUS, resourceTemplate.Phase)
-	//If request is failed then set failed message in state file
+	// If request is failed then set failed message in state file
 	if resourceTemplate.Phase == "FAILED" {
-		d.Set("failed_message", resourceTemplate.RequestCompletion.CompletionDetails)
+		log.Errorf(resourceTemplate.RequestCompletion.CompletionDetails)
+		d.Set(utils.FAILED_MESSAGE, resourceTemplate.RequestCompletion.CompletionDetails)
 	}
 
-	GetDeploymentStateData, errTemplate := vRAClient.GetDeploymentState(catalogItemRequestID)
+	requestResourceView, errTemplate := vRAClient.GetRequestResourceView(catalogItemRequestID)
 	if errTemplate != nil {
 		return fmt.Errorf("Resource view failed to load:  %v", errTemplate)
 	}
 
-	const reconfigGetLinkTitleRel = "GET Template: {com.vmware.csp.component.iaas.proxy.provider@resource.action.name." +
-		"machine.Reconfigure}"
-
-	var childConfig map[string]interface{}
-	childConfig = map[string]interface{}{}
-
-	for _, value := range GetDeploymentStateData.Content {
-		resourceMap := value.(map[string]interface{})
-		resourceSpecificData := resourceMap["data"].(map[string]interface{})
-		resourceSpecificLinks := resourceMap["links"].([]interface{})
-		if resourceSpecificData["Component"] != nil {
-			componentName := resourceSpecificData["Component"].(string)
-			reconfigGetLink := readActionLink(resourceSpecificLinks, reconfigGetLinkTitleRel)
-
-			resourceActionTemplate, err := getResourceConfigTemplate(reconfigGetLink, d, meta)
-			if err != nil {
-				return err
-			}
-			childConfig[componentName] = resourceActionTemplate.Data
-
-			// get IP address
-			if ipAddress, ok := resourceSpecificData["ip_address"]; ok {
-				childConfig[componentName].(map[string]interface{})["ip_address"] = ipAddress.(string)
-			}
+	resourceDataMap := make(map[string]map[string]interface{})
+	for _, resource := range requestResourceView.Content {
+		if resource.ResourceType == utils.INFRASTRUCTURE_VIRTUAL {
+			resourceData := resource.ResourcesData
+			dataVals := make(map[string]interface{})
+			resourceDataMap[resourceData.Component] = dataVals
+			dataVals[utils.MACHINE_CPU] = resourceData.Cpu
+			dataVals[utils.MACHINE_STORAGE] = resourceData.Storage
+			dataVals[utils.IP_ADDRESS] = resourceData.IpAddress
+			dataVals[utils.MACHINE_MEMORY] = resourceData.Memory
+			dataVals[utils.MACHINE_NAME] = resourceData.MachineName
+			dataVals[utils.MACHINE_GUEST_OS] = resourceData.MachineGuestOperatingSystem
+			dataVals[utils.MACHINE_BP_NAME] = resourceData.MachineBlueprintName
+			dataVals[utils.MACHINE_TYPE] = resourceData.MachineType
+			dataVals[utils.MACHINE_RESERVATION_NAME] = resourceData.MachineReservationName
+			dataVals[utils.MACHINE_INTERFACE_TYPE] = resourceData.MachineInterfaceType
+			dataVals[utils.MACHINE_ID] = resourceData.MachineId
+			dataVals[utils.MACHINE_GROUP_NAME] = resourceData.MachineGroupName
+			dataVals[utils.MACHINE_DESTRUCTION_DATE] = resourceData.MachineDestructionDate
 		}
 	}
-
-	resourceConfiguration, _ := d.Get("resource_configuration").(map[string]interface{})
+	resourceConfiguration, _ := d.Get(utils.RESOURCE_CONFIGURATION).(map[string]interface{})
 	changed := false
 
-	resourceConfiguration, changed = updateResourceConfigurationMap(resourceConfiguration, childConfig)
+	resourceConfiguration, changed = updateResourceConfigurationMap(resourceConfiguration, resourceDataMap)
 
 	if changed {
-		setError := d.Set("resource_configuration", resourceConfiguration)
+		setError := d.Set(utils.RESOURCE_CONFIGURATION, resourceConfiguration)
 		if setError != nil {
 			return fmt.Errorf(setError.Error())
 		}
 	}
-
 	return nil
 }
 
-func getResourceConfigTemplate(reconfigGetLink string, d *schema.ResourceData, meta interface{}) (*ResourceActionTemplate, error) {
-	vRAClient := meta.(*APIClient)
-	resourceActionTemplate := new(ResourceActionTemplate)
-	apiError := new(APIError)
-	//Get reource child reconfiguration template json
-	resp, err := vRAClient.HTTPClient.New().Get(reconfigGetLink).Receive(resourceActionTemplate, apiError)
-	resp.Close = true
-	if !apiError.isEmpty() {
-		return nil, apiError
-	}
-	if err != nil {
-		if err.Error() == "invalid character '<' looking for beginning of value" {
-			d.Set(utils.REQUEST_STATUS, "IN_PROGRESS")
-			return nil, fmt.Errorf("resource is not yet ready to show up")
-		}
-		return nil, err
-	}
-	return resourceActionTemplate, nil
-}
-
-// updateResourceConfigurationMap - updates the tf resource > resource_configuration type interface with given values
-// Input:
-// resourceConfiguration map[string]interface{} : tf resource_configuration
-// childConfig map[string]interface{} : data of deployment VMs
-// Output:
-// resourceConfiguration : updated resource_configuration map[string]interface data
-// changed : boolean for data got changed or not
+// update the resource configuration with the deployment resource data.
+// if there is difference between the config data and deployment data, return true
 func updateResourceConfigurationMap(
-	resourceConfiguration map[string]interface{}, vmData map[string]interface{}) (map[string]interface{}, bool) {
+	resourceConfiguration map[string]interface{}, vmData map[string]map[string]interface{}) (map[string]interface{}, bool) {
+	log.Info("Updating resource configuration with the request resource view data...")
 	var changed bool
 	for configKey1, configValue1 := range resourceConfiguration {
 		for configKey2, configValue2 := range vmData {
 			if strings.HasPrefix(configKey1, configKey2+".") {
 				trimmedKey := strings.TrimPrefix(configKey1, configKey2+".")
 				currentValue := configValue1
-				updatedValue := getTemplateFieldValue(configValue2.(map[string]interface{}), trimmedKey)
+				updatedValue := convertInterfaceToString(configValue2[trimmedKey])
 
-				if updatedValue != nil && updatedValue != currentValue {
+				if updatedValue != "" && updatedValue != currentValue {
 					resourceConfiguration[configKey1] = updatedValue
 					changed = true
 				}
@@ -655,26 +390,6 @@ func updateResourceConfigurationMap(
 		}
 	}
 	return resourceConfiguration, changed
-}
-
-//getTemplateFieldValue is use to check and return value of argument key
-func getTemplateFieldValue(template map[string]interface{}, key string) interface{} {
-	for k, v := range template {
-		//If value type is map then set recursive call which will fiend field in one level down of map interface
-		if reflect.ValueOf(v).Kind() == reflect.Map {
-			template, _ := v.(map[string]interface{})
-			resp := getTemplateFieldValue(template, key)
-			if resp != nil {
-				return convertInterfaceToString(resp)
-			}
-		} else if k == key {
-			//If value type is not map then compare field name with provided field name
-			//If both matches then update field value with provided value
-			return convertInterfaceToString(v)
-		}
-	}
-
-	return nil
 }
 
 func convertInterfaceToString(interfaceData interface{}) string {
@@ -686,9 +401,11 @@ func convertInterfaceToString(interfaceData interface{}) string {
 		stringData =
 			strconv.FormatFloat(interfaceData.(float64), 'f', 0, 32)
 	} else if reflect.ValueOf(interfaceData).Kind() == reflect.Int {
-		stringData = strconv.FormatInt(interfaceData.(int64), 10)
-	} else {
+		stringData = strconv.Itoa(interfaceData.(int))
+	} else if reflect.ValueOf(interfaceData).Kind() == reflect.String {
 		stringData = interfaceData.(string)
+	} else if reflect.ValueOf(interfaceData).Kind() == reflect.Bool {
+		stringData = strconv.FormatBool(interfaceData.(bool))
 	}
 	return stringData
 }
@@ -705,6 +422,22 @@ func deleteResource(d *schema.ResourceData, meta interface{}) error {
 	if len(d.Id()) == 0 {
 		return fmt.Errorf("Resource not found")
 	}
+
+	ResourceActions := new(ResourceActions)
+	apiError := new(APIError)
+
+	_, err := vRAClient.HTTPClient.New().Get("/catalog-service/api/consumer/resources/"+d.Id()+"/actions").
+		Receive(ResourceActions, apiError)
+
+	if err != nil {
+		log.Errorf("error while reading resource actions for the request %v ", d.Id())
+	}
+	if apiError != nil {
+		log.Errorf("API error while reading resource actions for the request %v ", d.Id())
+	}
+
+	log.Info("the resource action struct is %v", ResourceActions)
+
 	//If resource create status is in_progress then skip delete call and through an exception
 	if d.Get(utils.REQUEST_STATUS).(string) != "SUCCESSFUL" {
 		if d.Get(utils.REQUEST_STATUS).(string) == "FAILED" {
@@ -740,7 +473,7 @@ func deleteResource(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Destory Machine machine operation failed: %v", errDestroyMachine)
 	}
 
-	waitTimeout := d.Get("wait_timeout").(int) * 60
+	waitTimeout := d.Get(utils.WAIT_TIME_OUT).(int) * 60
 	sleepFor := 30
 	for i := 0; i < waitTimeout/sleepFor; i++ {
 		time.Sleep(time.Duration(sleepFor) * time.Second)
@@ -757,7 +490,7 @@ func deleteResource(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.Id() != "" {
 		d.SetId("")
-		return fmt.Errorf("resource still being deleted after %v minutes", d.Get("wait_timeout"))
+		return fmt.Errorf("resource still being deleted after %v minutes", d.Get(utils.WAIT_TIME_OUT))
 	}
 	return nil
 }
@@ -825,9 +558,9 @@ func (vRAClient *APIClient) PowerOffMachine(powerOffTemplate *ActionTemplate, re
 
 //GetRequestStatus - To read request status of resource
 // which is used to show information to user post create call.
-func (vRAClient *APIClient) GetRequestStatus(ResourceID string) (*RequestStatusView, error) {
+func (vRAClient *APIClient) GetRequestStatus(requestId string) (*RequestStatusView, error) {
 	//Form a URL to read request status
-	path := fmt.Sprintf("catalog-service/api/consumer/requests/%s", ResourceID)
+	path := fmt.Sprintf("catalog-service/api/consumer/requests/%s", requestId)
 	RequestStatusViewTemplate := new(RequestStatusView)
 	apiError := new(APIError)
 	//Set a REST call and fetch a resource request status
@@ -857,6 +590,21 @@ func (vRAClient *APIClient) GetDeploymentState(CatalogRequestId string) (*Resour
 		return nil, apiError
 	}
 	return ResourceView, nil
+}
+
+// Retrieves the resources that were provisioned as a result of a given request.
+func (vRAClient *APIClient) GetRequestResourceView(catalogRequestId string) (*RequestResourceView, error) {
+	path := fmt.Sprintf(utils.GET_REQUEST_RESOURCE_VIEW_API, catalogRequestId)
+	requestResourceView := new(RequestResourceView)
+	apiError := new(APIError)
+	_, err := vRAClient.HTTPClient.New().Get(path).Receive(requestResourceView, apiError)
+	if err != nil {
+		return nil, err
+	}
+	if !apiError.isEmpty() {
+		return nil, apiError
+	}
+	return requestResourceView, nil
 }
 
 //RequestCatalogItem - Make a catalog request.
@@ -891,8 +639,59 @@ func (vRAClient *APIClient) RequestCatalogItem(requestTemplate *CatalogItemReque
 }
 
 // check if the resource configuration is valid in the terraform config file
-func checkConfigValidity(requestTemplate *CatalogItemRequestTemplate, resourceConfiguration map[string]interface{}) error {
+func checkConfigValidity(vRAClient *APIClient, d *schema.ResourceData, requestTemplate *CatalogItemRequestTemplate) error {
 	log.Info("Checking if the terraform config file is valid")
+	// If catalog_name and catalog_id both not provided then return an error
+	if len(catalogItemName) <= 0 && len(catalogItemID) <= 0 {
+		return fmt.Errorf("Either catalog_name or catalog_id should be present in given configuration")
+	}
+
+	// If catalog item name is provided then get catalog item ID using name for further process
+	// else if catalog item id is provided then fetch catalog name
+	if len(catalogItemName) > 0 {
+		catalogItemID, returnErr := vRAClient.readCatalogItemIDByName(catalogItemName)
+		log.Info("The catalog item id provided in the config is %v\n", catalogItemID)
+		if returnErr != nil {
+			return fmt.Errorf("%v", returnErr)
+		}
+		if catalogItemID == nil && catalogItemID == "" {
+			return fmt.Errorf("No catalog item found with name %v", catalogItemID)
+		}
+		d.Set(utils.CATALOG_ID, catalogItemID.(string))
+	} else if len(catalogItemID) > 0 {
+		CatalogItemName, nameError := vRAClient.readCatalogItemNameByID(catalogItemName)
+		if nameError != nil {
+			return fmt.Errorf("%v", nameError)
+		}
+		if nameError != nil {
+			d.Set(utils.CATALOG_NAME, CatalogItemName.(string))
+		}
+	}
+
+	for field1 := range catalogConfiguration {
+		requestTemplate.Data[field1] = catalogConfiguration[field1]
+
+	}
+	// get the business group id from name
+	var businessGroupIdFromName string
+	if len(businessGroupName) > 0 {
+		businessGroupIdFromName, err := vRAClient.GetBusinessGroupId(businessGroupName)
+		if err != nil || businessGroupIdFromName == "" {
+			return err
+		}
+	}
+
+	//if both business group name and id are provided but does not belong to the same business group, throw an error
+	if len(businessGroupName) > 0 && len(businessGroupId) > 0 && businessGroupIdFromName != businessGroupId {
+		log.Error("The business group name %s and id %s does not belong to the same business group. Provide either name or id.", businessGroupName, businessGroupId)
+		return errors.New(fmt.Sprintf("The business group name %s and id %s does not belong to the same business group. Provide either name or id.", businessGroupName, businessGroupId))
+	} else if len(businessGroupId) > 0 { // else if both are provided and matches or just id is provided, use id
+		log.Info("Setting business group id %s ", businessGroupId)
+		requestTemplate.BusinessGroupID = businessGroupId
+	} else if len(businessGroupName) > 0 { // else if name is provided, use the id fetched from the name
+		log.Info("Setting business group id %s for the group %s ", businessGroupIdFromName, businessGroupName)
+		requestTemplate.BusinessGroupID = businessGroupIdFromName
+	}
 
 	// Get all component names in the blueprint corresponding to the catalog item.
 	componentSet := make(map[string]bool)
@@ -935,7 +734,7 @@ func checkConfigValidity(requestTemplate *CatalogItemRequestTemplate, resourceCo
 // check the request status on apply and update
 func waitForRequestCompletion(d *schema.ResourceData, meta interface{}) error {
 
-	waitTimeout := d.Get("wait_timeout").(int) * 60
+	waitTimeout := d.Get(utils.WAIT_TIME_OUT).(int) * 60
 	sleepFor := 30
 	request_status := ""
 	for i := 0; i < waitTimeout/sleepFor; i++ {
@@ -953,7 +752,7 @@ func waitForRequestCompletion(d *schema.ResourceData, meta interface{}) error {
 			//If request is failed during the time then
 			//unset resource details from state.
 			d.SetId("")
-			return fmt.Errorf("Resource creation FAILED.")
+			return fmt.Errorf("Request failed \n %v ", d.Get(utils.FAILED_MESSAGE))
 		} else if request_status == "IN_PROGRESS" {
 			log.Info("Resource creation is still IN PROGRESS.")
 		} else {
@@ -984,4 +783,28 @@ func (vRAClient *APIClient) GetBusinessGroupId(businessGroupName string) (string
 	// with the name businessGroupName.
 	// Fetch the id of that BG
 	return BusinessGroups.Content[0].Id, nil
+}
+
+// read the config file
+func readProviderConfiguration(d *schema.ResourceData) {
+
+	log.Info("Reading the provider configuration data.....")
+	catalogItemName = strings.TrimSpace(d.Get(utils.CATALOG_NAME).(string))
+	log.Info("Catalog item name: %v ", catalogItemName)
+	catalogItemID = strings.TrimSpace(d.Get(utils.CATALOG_ID).(string))
+	log.Info("Catalog item ID: %v", catalogItemID)
+	businessGroupName = strings.TrimSpace(d.Get(utils.BUSINESS_GROUP_NAME).(string))
+	log.Info("Business Group name: %v", businessGroupName)
+	businessGroupId = strings.TrimSpace(d.Get(utils.BUSINESS_GROUP_ID).(string))
+	log.Info("Business Group Id: %v", businessGroupId)
+	waitTimeout = d.Get(utils.WAIT_TIME_OUT).(int) * 60
+	log.Info("Wait time out: %v ", waitTimeout)
+	failedMessage = strings.TrimSpace(d.Get(utils.FAILED_MESSAGE).(string))
+	log.Info("Failed message: %v ", failedMessage)
+	resourceConfiguration = d.Get(utils.RESOURCE_CONFIGURATION).(map[string]interface{})
+	log.Info("Resource Configuration: %v ", resourceConfiguration)
+	deploymentConfiguration = d.Get(utils.DEPLOYMENT_CONFIGURATION).(map[string]interface{})
+	log.Info("Deployment Configuration: %v ", deploymentConfiguration)
+	catalogConfiguration = d.Get(utils.CATALOG_CONFIGURATION).(map[string]interface{})
+	log.Info("Catalog configuration: %v ", catalogConfiguration)
 }

--- a/vrealize/resource_test.go
+++ b/vrealize/resource_test.go
@@ -301,7 +301,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockResourceData := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
 
 	readProviderConfiguration(mockResourceData)
-	err := checkConfigValidity(mockRequestTemplate)
+	err := checkResourceConfigValidity(mockRequestTemplate)
 	if err != nil {
 		t.Errorf("The terraform config is valid, failed to validate. Expecting no error, but found %v ", err.Error())
 	}
@@ -317,7 +317,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockResourceData = schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
 	readProviderConfiguration(mockResourceData)
 
-	err = checkConfigValidity(mockRequestTemplate)
+	err = checkResourceConfigValidity(mockRequestTemplate)
 	if err != nil {
 		t.Errorf("The terraform config is valid, failed to validate. Expecting no error, but found %v ", err.Error())
 	}
@@ -335,7 +335,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockInvalidKeys = append(mockInvalidKeys, "mock.machine3.vSphere.mock.cpu")
 
 	validityErr := fmt.Sprintf(utils.CONFIG_INVALID_ERROR, strings.Join(mockInvalidKeys, ", "))
-	err = checkConfigValidity(mockRequestTemplate)
+	err = checkResourceConfigValidity(mockRequestTemplate)
 	// this should throw an error as none of the string combinations (mock, mock.machine3, mock.machine3.vsphere, etc)
 	// matches the component names(mock.test.machine1 and machine2) in the request template
 	if err == nil {

--- a/vrealize/resource_test.go
+++ b/vrealize/resource_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/terraform-provider-vra7/utils"
 	"gopkg.in/jarcoal/httpmock.v1"
 )
@@ -290,7 +291,17 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockConfigResourceMap["mock.test.machine1.cpu"] = 2
 	mockConfigResourceMap["mock.test.machine1.mock.storage"] = 8
 
-	err := checkConfigValidity(mockRequestTemplate, mockConfigResourceMap)
+	resourceSchema := resourceSchema()
+
+	resourceDataMap := map[string]interface{}{
+		utils.CATALOG_ID:             "abcdefghijklmn",
+		utils.RESOURCE_CONFIGURATION: mockConfigResourceMap,
+	}
+
+	mockResourceData := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
+
+	readProviderConfiguration(mockResourceData)
+	err := checkConfigValidity(&client, mockResourceData, mockRequestTemplate)
 	if err != nil {
 		t.Errorf("The terraform config is valid, failed to validate. Expecting no error, but found %v ", err.Error())
 	}
@@ -298,7 +309,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockConfigResourceMap["machine2.mock.cpu"] = 2
 	mockConfigResourceMap["machine2.storage"] = 2
 
-	err = checkConfigValidity(mockRequestTemplate, mockConfigResourceMap)
+	err = checkConfigValidity(&client, mockResourceData, mockRequestTemplate)
 	if err != nil {
 		t.Errorf("The terraform config is valid, failed to validate. Expecting no error, but found %v ", err.Error())
 	}
@@ -309,7 +320,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockInvalidKeys = append(mockInvalidKeys, "mock.machine3.vSphere.mock.cpu")
 
 	validityErr := fmt.Sprintf(utils.CONFIG_INVALID_ERROR, strings.Join(mockInvalidKeys, ", "))
-	err = checkConfigValidity(mockRequestTemplate, mockConfigResourceMap)
+	err = checkConfigValidity(&client, mockResourceData, mockRequestTemplate)
 	// this should throw an error as none of the string combinations (mock, mock.machine3, mock.machine3.vsphere, etc)
 	// matches the component names(mock.test.machine1 and machine2) in the request template
 	if err == nil {

--- a/vrealize/resource_test.go
+++ b/vrealize/resource_test.go
@@ -301,7 +301,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockResourceData := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
 
 	readProviderConfiguration(mockResourceData)
-	err := checkConfigValidity(&client, mockResourceData, mockRequestTemplate)
+	err := checkConfigValidity(mockRequestTemplate)
 	if err != nil {
 		t.Errorf("The terraform config is valid, failed to validate. Expecting no error, but found %v ", err.Error())
 	}
@@ -309,18 +309,33 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockConfigResourceMap["machine2.mock.cpu"] = 2
 	mockConfigResourceMap["machine2.storage"] = 2
 
-	err = checkConfigValidity(&client, mockResourceData, mockRequestTemplate)
+	resourceDataMap = map[string]interface{}{
+		utils.CATALOG_ID:             "abcdefghijklmn",
+		utils.RESOURCE_CONFIGURATION: mockConfigResourceMap,
+	}
+
+	mockResourceData = schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
+	readProviderConfiguration(mockResourceData)
+
+	err = checkConfigValidity(mockRequestTemplate)
 	if err != nil {
 		t.Errorf("The terraform config is valid, failed to validate. Expecting no error, but found %v ", err.Error())
 	}
 
 	mockConfigResourceMap["mock.machine3.vSphere.mock.cpu"] = 2
+	resourceDataMap = map[string]interface{}{
+		utils.CATALOG_ID:             "abcdefghijklmn",
+		utils.RESOURCE_CONFIGURATION: mockConfigResourceMap,
+	}
+
+	mockResourceData = schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
+	readProviderConfiguration(mockResourceData)
 
 	var mockInvalidKeys []string
 	mockInvalidKeys = append(mockInvalidKeys, "mock.machine3.vSphere.mock.cpu")
 
 	validityErr := fmt.Sprintf(utils.CONFIG_INVALID_ERROR, strings.Join(mockInvalidKeys, ", "))
-	err = checkConfigValidity(&client, mockResourceData, mockRequestTemplate)
+	err = checkConfigValidity(mockRequestTemplate)
 	// this should throw an error as none of the string combinations (mock, mock.machine3, mock.machine3.vsphere, etc)
 	// matches the component names(mock.test.machine1 and machine2) in the request template
 	if err == nil {

--- a/vrealize/schema.go
+++ b/vrealize/schema.go
@@ -1,0 +1,271 @@
+package vrealize
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vmware/terraform-provider-vra7/utils"
+)
+
+//ResourceActionTemplate - is used to store information
+//related to resource action template information.
+type ResourceActionTemplate struct {
+	Type        string                 `json:"type"`
+	ResourceID  string                 `json:"resourceId"`
+	ActionID    string                 `json:"actionId"`
+	Description string                 `json:"description"`
+	Data        map[string]interface{} `json:"data"`
+}
+
+//ResourceView - is used to store information
+//related to resource template information.
+type ResourceView struct {
+	Content []interface {
+	} `json:"content"`
+	Links []interface{} `json:"links"`
+}
+
+//RequestStatusView - used to store REST response of
+//request triggered against any resource.
+type RequestStatusView struct {
+	RequestCompletion struct {
+		RequestCompletionState string `json:"requestCompletionState"`
+		CompletionDetails      string `json:"CompletionDetails"`
+	} `json:"requestCompletion"`
+	Phase string `json:"phase"`
+}
+
+type BusinessGroups struct {
+	Content []BusinessGroup `json:"content,omitempty"`
+}
+
+type BusinessGroup struct {
+	Name string `json:"name,omitempty"`
+	Id   string `json:"id,omitempty"`
+}
+
+// Resource View of a provisioned request
+type RequestResourceView struct {
+	Content []DeploymentResource `json:"content,omitempty"`
+	Links   []interface{}        `json:"links,omitempty"`
+}
+
+type DeploymentResource struct {
+	RequestState    string                 `json:"requestState,omitempty"`
+	Description     string                 `json:"description,omitempty"`
+	LastUpdated     string                 `json:"lastUpdated,omitempty"`
+	TenantId        string                 `json:"tenantId,omitempty"`
+	Name            string                 `json:"name,omitempty"`
+	BusinessGroupId string                 `json:"businessGroupId,omitempty"`
+	DateCreated     string                 `json:"dateCreated,omitempty"`
+	Status          string                 `json:"status,omitempty"`
+	RequestId       string                 `json:"requestId,omitempty"`
+	ResourceId      string                 `json:"resourceId,omitempty"`
+	ResourceType    string                 `json:"resourceType,omitempty"`
+	ResourcesData   DeploymentResourceData `json:"data,omitempty"`
+}
+
+type DeploymentResourceData struct {
+	Memory                      int    `json:"MachineMemory,omitempty"`
+	Cpu                         int    `json:"MachineCPU,omitempty"`
+	IpAddress                   string `json:"ip_address,omitempty"`
+	Storage                     int    `json:"MachineStorage,omitempty"`
+	MachineInterfaceType        string `json:"MachineInterfaceType,omitempty"`
+	MachineName                 string `json:"MachineName,omitempty"`
+	MachineGuestOperatingSystem string `json:"MachineGuestOperatingSystem,omitempty"`
+	MachineDestructionDate      string `json:"MachineDestructionDate,omitempty"`
+	MachineGroupName            string `json:"MachineGroupName,omitempty"`
+	MachineBlueprintName        string `json:"MachineBlueprintName,omitempty"`
+	MachineReservationName      string `json:"MachineReservationName,omitempty"`
+	MachineType                 string `json:"MachineType,omitempty"`
+	MachineId                   string `json:"machineId,omitempty"`
+	MachineExpirationDate       string `json:"MachineExpirationDate,omitempty"`
+	Component                   string `json:"Component,omitempty"`
+	Expire                      bool   `json:"Expire,omitempty"`
+	Reconfigure                 bool   `json:"Reconfigure,omitempty"`
+	Reset                       bool   `json:"Reset,omitempty"`
+	Reboot                      bool   `json:"Reboot,omitempty"`
+	PowerOff                    bool   `json:"PowerOff,omitempty"`
+	Destroy                     bool   `json:"Destroy,omitempty"`
+	Shutdown                    bool   `json:"Shutdown,omitempty"`
+	Suspend                     bool   `json:"Suspend,omitempty"`
+	Reprovision                 bool   `json:"Reprovision,omitempty"`
+	ChangeLease                 bool   `json:"ChangeLease,omitempty"`
+	ChangeOwner                 bool   `json:"ChangeOwner,omitempty"`
+	CreateSnapshot              bool   `json:"CreateSnapshot,omitempty"`
+}
+
+// Retrieves the resources that were provisioned as a result of a given request.
+// Also returns the actions allowed on the resources and their templates
+type ResourceActions struct {
+	Links   []string                `json:"links,omitempty"`
+	Content []ResourceActionContent `json:"content,omitempty"`
+}
+
+type ResourceActionContent struct {
+	Id              string          `json:"id,omitempty"`
+	Name            string          `json:"name,omitempty"`
+	ResourceTypeRef ResourceTypeRef `json:"resourceTypeRef,omitempty"`
+	Status          string          `json:"status,omitempty"`
+	RequestId       string          `json:"requestId,omitempty"`
+	RequestState    string          `json:"requestState,omitempty"`
+	Operations      []Operation     `json:"operations,omitempty"`
+	ResourceData    ResourceDataMap `json:"resourceData,omitempty"`
+}
+
+type ResourceTypeRef struct {
+	Id    string `json:"id,omitempty"`
+	Label string `json:"label,omitempty"`
+}
+
+type Operation struct {
+	Name        string `json:"name,omitempty"`
+	OperationId string `json:"id,omitempty"`
+	Type        string `json:"type,omitempty"`
+	BindingId   string `json:"bindingId,omitempty"`
+}
+
+type ResourceDataMap struct {
+	Entries []ResourceDataEntry `json:"entries,omitempty"`
+}
+type ResourceDataEntry struct {
+	Key   string                 `json:"key,omitempty"`
+	Value ResourceDataEntryValue `json:"value,omitempty"`
+}
+type ResourceDataEntryValue struct {
+	Type  string      `json:"type,omitempty"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+//CatalogRequest - A structure that captures a vRA catalog request.
+type CatalogRequest struct {
+	ID           string      `json:"id"`
+	IconID       string      `json:"iconId"`
+	Version      int         `json:"version"`
+	State        string      `json:"state"`
+	Description  string      `json:"description"`
+	Reasons      interface{} `json:"reasons"`
+	RequestedFor string      `json:"requestedFor"`
+	RequestedBy  string      `json:"requestedBy"`
+	Organization struct {
+		TenantRef      string `json:"tenantRef"`
+		TenantLabel    string `json:"tenantLabel"`
+		SubtenantRef   string `json:"subtenantRef"`
+		SubtenantLabel string `json:"subtenantLabel"`
+	} `json:"organization"`
+
+	RequestorEntitlementID   string                 `json:"requestorEntitlementId"`
+	PreApprovalID            string                 `json:"preApprovalId"`
+	PostApprovalID           string                 `json:"postApprovalId"`
+	DateCreated              time.Time              `json:"dateCreated"`
+	LastUpdated              time.Time              `json:"lastUpdated"`
+	DateSubmitted            time.Time              `json:"dateSubmitted"`
+	DateApproved             time.Time              `json:"dateApproved"`
+	DateCompleted            time.Time              `json:"dateCompleted"`
+	Quote                    interface{}            `json:"quote"`
+	RequestData              map[string]interface{} `json:"requestData"`
+	RequestCompletion        string                 `json:"requestCompletion"`
+	RetriesRemaining         int                    `json:"retriesRemaining"`
+	RequestedItemName        string                 `json:"requestedItemName"`
+	RequestedItemDescription string                 `json:"requestedItemDescription"`
+	Components               string                 `json:"components"`
+	StateName                string                 `json:"stateName"`
+
+	CatalogItemProviderBinding struct {
+		BindingID   string `json:"bindingId"`
+		ProviderRef struct {
+			ID    string `json:"id"`
+			Label string `json:"label"`
+		} `json:"providerRef"`
+	} `json:"catalogItemProviderBinding"`
+
+	Phase           string `json:"phase"`
+	ApprovalStatus  string `json:"approvalStatus"`
+	ExecutionStatus string `json:"executionStatus"`
+	WaitingStatus   string `json:"waitingStatus"`
+	CatalogItemRef  struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+	} `json:"catalogItemRef"`
+}
+
+//ResourceMachine - use to set resource fields
+func ResourceMachine() *schema.Resource {
+	return &schema.Resource{
+		Create: createResource,
+		Read:   readResource,
+		Update: updateResource,
+		Delete: deleteResource,
+		Schema: resourceSchema(),
+	}
+}
+
+//set_resource_schema - This function is used to update the catalog item template/blueprint
+//and replace the values with user defined values added in .tf file.
+func resourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		utils.CATALOG_NAME: {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		utils.CATALOG_ID: {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		utils.BUSINESS_GROUP_ID: {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		utils.BUSINESS_GROUP_NAME: {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		utils.WAIT_TIME_OUT: {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  15,
+		},
+		utils.REQUEST_STATUS: {
+			Type:     schema.TypeString,
+			Computed: true,
+			ForceNew: true,
+		},
+		utils.FAILED_MESSAGE: {
+			Type:     schema.TypeString,
+			Computed: true,
+			ForceNew: true,
+			Optional: true,
+		},
+		utils.DEPLOYMENT_CONFIGURATION: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
+		utils.RESOURCE_CONFIGURATION: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
+		utils.CATALOG_CONFIGURATION: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
+	}
+}


### PR DESCRIPTION
1. When reconfigure machine action is not enabled in the entitlement, do not allow update
2. In read resource, do not populate reconfigure template, just show whatever the provisioned request resource returns
3. Check the validity of config file in both create and update resource
4. Call appropriate vRA APIs to get the allowed actions on a provisioned resource
5. Return the failure message from the API when a request fails.
6. Code clean up: Handle error scenarios, add string constants, separate schema in a different file
Signed-off-by: Prativa Bawri <bawrip@vmware.com>