### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ export GOROOT=/usr/local/go
 export GOPATH=/home/<user>/TerraformPluginProject
 ```
 
+*GO111MODULE is a golang module mode flag (outside of GOPATH, you do not need to set GO111MODULE to activate module mode)*
+```
+export GO111MODULE=on
+```
+
 **Windows Users**
 
 *GOROOT is a golang library path*
@@ -51,6 +56,11 @@ set GOROOT=C:\Go
 *GOPATH is a path pointing toward the source code directory*
 ```
 set GOPATH=C:\TerraformPluginProject
+```
+
+*GO111MODULE is a golang module mode flag (outside of GOPATH, you do not need to set GO111MODULE to activate module mode)*
+```
+set GO111MODULE=on
 ```
 
 ## Set terraform provider


### PR DESCRIPTION
After switching from dep to opt-in experimental go modules new feature available from go 11.1 the present file does not include an explicit reference that immediately alerts the user for this new requirement.

Introduced in commit https://github.com/vmware/terraform-provider-vra7/commit/c56915cd5b41ad8b37a6eb77e710ecb2fcdf65f4
Go modules details can be read in https://github.com/golang/go/wiki/Modules