### PR TITLE
Add requirement for go 1.11.4 or above

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These instructions will get you a copy of the project up and run on your local m
 
 To get the vRA plugin up and running you need the following things.
 * [Terraform 0.9 or above](https://www.terraform.io/downloads.html)
-* [Go Language 1.11 or above](https://golang.org/dl/)
+* [Go Language 1.11.4 or above](https://golang.org/dl/)
 
 ## Project Setup
 


### PR DESCRIPTION
The "go mod" changes required 1.11 or above but due to a bug
the checksum file could be incorrect for releases before 1.11.4.
Make this requirement more explicit in the README.
Reference: https://github.com/golang/go/issues/29278