### PR TITLE
Don't auth if there is an existing bearer token

### DIFF
--- a/sdk/vra_client.go
+++ b/sdk/vra_client.go
@@ -38,7 +38,9 @@ func (c *APIClient) DoRequest(req *APIRequest, login bool) (*APIResponse, error)
 		return nil, err
 	}
 	if !login {
-		c.Authenticate()
+		if c.BearerToken == "" {
+			c.Authenticate()
+		}
 		r.Header.Add(AuthorizationHeader, c.BearerToken)
 	}
 	r.Header.Add(ConnectionHeader, CloseConnection)


### PR DESCRIPTION
The sdk client was requesting a new bearer token for each api call. This change will look for and use an existing bearer token prior to going through the authorization.