### PR TITLE
Addressing Hashicorp certification review comments

### DIFF
--- a/vra7/provider.go
+++ b/vra7/provider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/terraform-provider-vra7/sdk"
-	"github.com/vmware/terraform-provider-vra7/utils"
 )
 
 //Provider - This function initializes the provider schema
@@ -15,7 +14,9 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema:        providerSchema(),
 		ConfigureFunc: providerConfig,
-		ResourcesMap:  providerResources(),
+		ResourcesMap: map[string]*schema.Resource{
+			"vra7_deployment": resourceVra7Deployment(),
+		},
 	}
 }
 
@@ -57,88 +58,6 @@ func providerSchema() map[string]*schema.Schema {
 	}
 }
 
-//ResourceMachine - use to set resource fields
-func ResourceMachine() *schema.Resource {
-	return &schema.Resource{
-		Create: createResource,
-		Read:   readResource,
-		Update: updateResource,
-		Delete: deleteResource,
-		Schema: resourceSchema(),
-	}
-}
-
-//set_resource_schema - This function is used to update the catalog item template/blueprint
-//and replace the values with user defined values added in .tf file.
-func resourceSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		utils.CatalogItemName: {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		utils.CatalogItemID: {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		utils.Description: {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		utils.Reasons: {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		utils.BusinessGroupID: {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		utils.BusinessGroupName: {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		utils.WaitTimeout: {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Default:  15,
-		},
-		utils.RequestStatus: {
-			Type:     schema.TypeString,
-			Computed: true,
-			ForceNew: true,
-		},
-		utils.FailedMessage: {
-			Type:     schema.TypeString,
-			Computed: true,
-			ForceNew: true,
-			Optional: true,
-		},
-		utils.DeploymentConfiguration: {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-			},
-		},
-		utils.ResourceConfiguration: {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-			},
-		},
-	}
-}
-
 //Function use - To authenticate terraform provider
 func providerConfig(r *schema.ResourceData) (interface{}, error) {
 	//Create a client handle to perform REST calls for various operations upon the resource
@@ -160,11 +79,4 @@ func providerConfig(r *schema.ResourceData) (interface{}, error) {
 
 	//Return client handle on success
 	return &vraClient, nil
-}
-
-//Function use - set machine resource details based on machine type
-func providerResources() map[string]*schema.Resource {
-	return map[string]*schema.Resource{
-		"vra7_deployment": ResourceMachine(),
-	}
 }

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -41,6 +41,82 @@ type ProviderSchema struct {
 	ResourceConfiguration   map[string]interface{}
 }
 
+func resourceVra7Deployment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVra7DeploymentCreate,
+		Read:   resourceVra7DeploymentRead,
+		Update: resourceVra7DeploymentUpdate,
+		Delete: resourceVra7DeploymentDelete,
+
+		Schema: map[string]*schema.Schema{
+			utils.CatalogItemName: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			utils.CatalogItemID: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			utils.Description: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			utils.Reasons: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			utils.BusinessGroupID: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			utils.BusinessGroupName: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			utils.WaitTimeout: {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  15,
+			},
+			utils.RequestStatus: {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+			utils.FailedMessage: {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+				Optional: true,
+			},
+			utils.DeploymentConfiguration: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     schema.TypeString,
+				},
+			},
+			utils.ResourceConfiguration: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
 // byLength type to sort component name list by it's name length
 type byLength []string
 
@@ -57,7 +133,7 @@ func (s byLength) Swap(i, j int) {
 // Terraform call - terraform apply
 // This function creates a new vRA 7 Deployment using configuration in a user's Terraform file.
 // The Deployment is produced by invoking a catalog item that is specified in the configuration.
-func createResource(d *schema.ResourceData, meta interface{}) error {
+func resourceVra7DeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 	vraClient = meta.(*sdk.APIClient)
 	// Get client handle
 	p := readProviderConfiguration(d)
@@ -130,7 +206,7 @@ func createResource(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	return readResource(d, meta)
+	return resourceVra7DeploymentRead(d, meta)
 }
 
 func updateRequestTemplate(templateInterface map[string]interface{}, field string, value interface{}) map[string]interface{} {
@@ -146,7 +222,7 @@ func updateRequestTemplate(templateInterface map[string]interface{}, field strin
 // Terraform call - terraform apply
 // This function updates the state of a vRA 7 Deployment when changes to a Terraform file are applied.
 // The update is performed on the Deployment using supported (day-2) actions.
-func updateResource(d *schema.ResourceData, meta interface{}) error {
+func resourceVra7DeploymentUpdate(d *schema.ResourceData, meta interface{}) error {
 	vraClient = meta.(*sdk.APIClient)
 	// Get the ID of the catalog request that was used to provision this Deployment.
 	catalogItemRequestID := d.Id()
@@ -247,13 +323,13 @@ func updateResource(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-	return readResource(d, meta)
+	return resourceVra7DeploymentRead(d, meta)
 }
 
 // Terraform call - terraform refresh
 // This function retrieves the latest state of a vRA 7 deployment. Terraform updates its state based on
 // the information returned by this function.
-func readResource(d *schema.ResourceData, meta interface{}) error {
+func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error {
 	vraClient = meta.(*sdk.APIClient)
 	// Get the ID of the catalog request that was used to provision this Deployment.
 	catalogItemRequestID := d.Id()
@@ -306,7 +382,7 @@ func readResource(d *schema.ResourceData, meta interface{}) error {
 
 //Function use - To delete resources which are created by terraform and present in state file
 //Terraform call - terraform destroy
-func deleteResource(d *schema.ResourceData, meta interface{}) error {
+func resourceVra7DeploymentDelete(d *schema.ResourceData, meta interface{}) error {
 	vraClient = meta.(*sdk.APIClient)
 	//Get requester machine ID from schema.dataresource
 	catalogItemRequestID := d.Id()

--- a/vra7/resource_vra7_deployment_test.go
+++ b/vra7/resource_vra7_deployment_test.go
@@ -31,7 +31,7 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockConfigResourceMap["mock.test.machine1.cpu"] = 2
 	mockConfigResourceMap["mock.test.machine1.mock.storage"] = 8
 
-	resourceSchema := resourceSchema()
+	resourceSchema := resourceVra7Deployment().Schema
 
 	resourceDataMap := map[string]interface{}{
 		utils.CatalogItemID:         "abcdefghijklmn",


### PR DESCRIPTION
1. The schema and resource for vra7_deployment should be in resource_vra7_deployment.go rather than provider.go. The function naming is a little confusing too. ResourceDeployment() would probably be more clear than ResourceMachine()

Signed-off-by: Prativa Bawri<bawrip@vmware.com>