### PR TITLE
Addressing certification review comments

### DIFF
--- a/utils/utilities.go
+++ b/utils/utilities.go
@@ -10,19 +10,6 @@ import (
 
 // terraform provider constants
 const (
-	CatalogItemName         = "catalog_item_name"
-	CatalogItemID           = "catalog_item_id"
-	Description             = "description"
-	Reasons                 = "reasons"
-	BusinessGroupID         = "businessgroup_id"
-	BusinessGroupName       = "businessgroup_name"
-	WaitTimeout             = "wait_timeout"
-	FailedMessage           = "failed_message"
-	DeploymentConfiguration = "deployment_configuration"
-	ResourceConfiguration   = "resource_configuration"
-	CatalogConfiguration    = "catalog_configuration"
-	RequestStatus           = "request_status"
-
 	// utility constants
 
 	LoggerID = "terraform-provider-vra7"

--- a/vra7/resource_vra7_deployment_test.go
+++ b/vra7/resource_vra7_deployment_test.go
@@ -34,8 +34,8 @@ func TestConfigValidityFunction(t *testing.T) {
 	resourceSchema := resourceVra7Deployment().Schema
 
 	resourceDataMap := map[string]interface{}{
-		utils.CatalogItemID:         "abcdefghijklmn",
-		utils.ResourceConfiguration: mockConfigResourceMap,
+		"catalog_item_id":        "abcdefghijklmn",
+		"resource_configuration": mockConfigResourceMap,
 	}
 
 	mockResourceData := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
@@ -50,8 +50,8 @@ func TestConfigValidityFunction(t *testing.T) {
 	mockConfigResourceMap["machine2.storage"] = 2
 
 	resourceDataMap = map[string]interface{}{
-		utils.CatalogItemID:         "abcdefghijklmn",
-		utils.ResourceConfiguration: mockConfigResourceMap,
+		"catalog_item_id":        "abcdefghijklmn",
+		"resource_configuration": mockConfigResourceMap,
 	}
 
 	mockResourceData = schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
@@ -62,8 +62,8 @@ func TestConfigValidityFunction(t *testing.T) {
 
 	mockConfigResourceMap["mock.machine3.vSphere.mock.cpu"] = 2
 	resourceDataMap = map[string]interface{}{
-		utils.CatalogItemID:         "abcdefghijklmn",
-		utils.ResourceConfiguration: mockConfigResourceMap,
+		"catalog_item_id":        "abcdefghijklmn",
+		"resource_configuration": mockConfigResourceMap,
 	}
 
 	mockResourceData = schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)


### PR DESCRIPTION
1. Attribute keys within the schema should not be read in from elsewhere. Making the Schema not embedded in the Resource is a bit non-standard, but ok. The setup should be simplified a bit though so it is easier to read and understand.

2. Any non-scalar values (TypeList, TypeSet, TypeMap) should have errors checked when setting.

Signed-off-by: Prativa Bawri<bawrip@vmware.com>