### PR TITLE
patch for SwisscomESC: use Destroy Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ resource "vra7_deployment" "example_machine2" {
 
 ```
 
+For Swisscom Enterprise Cloud you can set swisscom_esc = true to trigger advanced functions:
+
+```yaml
+resource "vra7_deployment" "example_machine1" {
+  swisscom_esc = true
+  catalog_item_name = "CentOS"
+  reasons      = "I have some"
+  description  = "deployment via terraform"
+   resource_configuration = {
+     }
+     deployment_configuration = {
+         _leaseDays = "5"
+     }
+     count = 1
+}
+```
+
 Save this configuration in `main.tf` in a path where the binary is placed.
 
 ## Execution

--- a/sdk/vra7_sdk.go
+++ b/sdk/vra7_sdk.go
@@ -53,6 +53,7 @@ const (
 	Component              = "Component"
 	Reconfigure            = "Reconfigure"
 	Destroy                = "Destroy"
+	DeploymentDestroy      = "Destroy Deployment"
 )
 
 // GetCatalogItemRequestTemplate - Call to retrieve a request template for a catalog item.


### PR DESCRIPTION
The provider fails with: Insufficient entitlement to destroy VM in vRA7 otherwise